### PR TITLE
Automate extracting WA results and uploading final outputs to S3

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -69,6 +69,14 @@ def _get_all_input(w):
             model=models_to_run,
             date=run_date
         ))
+        all_input.extend(expand(
+            "results/{data_provenance}/{variant_classification}/{geo_resolution}/{model}/{date}_washington.json",
+            data_provenance=data_provenances,
+            variant_classification=variant_classifications,
+            geo_resolution=geo_resolutions,
+            model=models_to_run,
+            date=run_date
+        ))
         if config.get("s3_dst"):
             all_input.extend(expand(
                 [
@@ -88,9 +96,9 @@ def _get_all_input(w):
 rule all:
     input: _get_all_input
 
-
 include: "workflow/snakemake_rules/prepare_data.smk"
 include: "workflow/snakemake_rules/models.smk"
+include: "workflow/snakemake_rules/extract_washington.smk"
 
 if config.get("send_slack_notifications"):
     include: "workflow/snakemake_rules/slack_notifications.smk"

--- a/Snakefile
+++ b/Snakefile
@@ -111,8 +111,11 @@ include: "workflow/snakemake_rules/prepare_data.smk"
 include: "workflow/snakemake_rules/models.smk"
 include: "workflow/snakemake_rules/extract_washington.smk"
 
-if config.get("sfa_s3_bucket"):
+if config.get("send_sfa_forecast_to_s3"):
     include: "workflow/snakemake_rules/upload_sfa_forecast.smk"
+
+# if config.get("sfa_s3_bucket"):
+#     include: "workflow/snakemake_rules/upload_sfa_forecast.smk"
 
 # if config.get("send_slack_notifications"):
 #     include: "workflow/snakemake_rules/slack_notifications.smk"

--- a/Snakefile
+++ b/Snakefile
@@ -78,7 +78,7 @@ def _get_all_input(w):
             date=run_date
         ))
 
-        if config.get("sfa_s3_bucket"):
+        if config.get("send_sfa_forecast_to_s3"):
             all_input.extend(expand(
                 "results/{data_provenance}/{variant_classification}/usa/{model}/{date}_s3_upload.done",
                 data_provenance=data_provenances,

--- a/Snakefile
+++ b/Snakefile
@@ -77,18 +77,29 @@ def _get_all_input(w):
             model=models_to_run,
             date=run_date
         ))
-        if config.get("s3_dst"):
+
+        if config.get("sfa_s3_bucket"):
             all_input.extend(expand(
-                [
-                    "results/{data_provenance}/{variant_classification}/{geo_resolution}/{model}/{date}_results_s3_upload.done",
-                    "results/{data_provenance}/{variant_classification}/{geo_resolution}/{model}/{date}_latest_results_s3_upload.done"
-                ],
+                "results/{data_provenance}/{variant_classification}/usa/{model}/{date}_s3_upload.done",
                 data_provenance=data_provenances,
                 variant_classification=variant_classifications,
                 geo_resolution=geo_resolutions,
                 model=models_to_run,
                 date=run_date
             ))
+                
+        # if config.get("s3_dst"):
+        #     all_input.extend(expand(
+        #         [
+        #             "results/{data_provenance}/{variant_classification}/{geo_resolution}/{model}/{date}_results_s3_upload.done",
+        #             "results/{data_provenance}/{variant_classification}/{geo_resolution}/{model}/{date}_latest_results_s3_upload.done"
+        #         ],
+        #         data_provenance=data_provenances,
+        #         variant_classification=variant_classifications,
+        #         geo_resolution=geo_resolutions,
+        #         model=models_to_run,
+        #         date=run_date
+        #     ))
 
     return all_input
 
@@ -100,8 +111,11 @@ include: "workflow/snakemake_rules/prepare_data.smk"
 include: "workflow/snakemake_rules/models.smk"
 include: "workflow/snakemake_rules/extract_washington.smk"
 
-if config.get("send_slack_notifications"):
-    include: "workflow/snakemake_rules/slack_notifications.smk"
+if config.get("sfa_s3_bucket"):
+    include: "workflow/snakemake_rules/upload_sfa_forecast.smk"
 
-if config.get("s3_dst"):
-    include: "workflow/snakemake_rules/upload.smk"
+# if config.get("send_slack_notifications"):
+#     include: "workflow/snakemake_rules/slack_notifications.smk"
+
+# if config.get("s3_dst"):
+#     include: "workflow/snakemake_rules/upload.smk"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -180,3 +180,9 @@ clade_definitions:
     display_name: "other"
     defining_lineage: False
     color: '#777777'
+
+# param for sending forecast output to public s3 bucket
+# if true, will send to public s3 bucket,
+# and the website will automatically be updated.
+# the s3 bucket is configured as an environment variable.
+send_sfa_forecast_to_s3: True

--- a/config/sfa-optional.yaml
+++ b/config/sfa-optional.yaml
@@ -1,0 +1,4 @@
+# Optional configs used by the SFA team
+
+#sfa_s3_bucket: "bbi-sfa-covidforecasting-dashboard-ui"
+sfa_s3_bucket: "bbi-sfa-nextstrain-work"

--- a/config/sfa-optional.yaml
+++ b/config/sfa-optional.yaml
@@ -1,4 +1,4 @@
 # Optional configs used by the SFA team
 
 #sfa_s3_bucket: "bbi-sfa-covidforecasting-dashboard-ui"
-sfa_s3_bucket: "bbi-sfa-nextstrain-work"
+sfa_s3_bucket: "bbi-sfa-nextstrain-work-prod"

--- a/config/sfa-optional.yaml
+++ b/config/sfa-optional.yaml
@@ -1,4 +1,0 @@
-# Optional configs used by the SFA team
-
-#sfa_s3_bucket: "bbi-sfa-covidforecasting-dashboard-ui"
-sfa_s3_bucket: "bbi-sfa-nextstrain-work-prod"

--- a/forecasts-ncov-states.md
+++ b/forecasts-ncov-states.md
@@ -1,0 +1,47 @@
+# Forecasting pipeline
+
+This documentation is specific to running the forecasting models for US and Washington state to update [this page](https://seattleflu.org/sars-cov-2-forecasts) on the SFA public website.
+
+## Setup
+
+### Requirements
+
+- Nextclade CLI (can be installed [directly](https://docs.nextstrain.org/projects/cli/en/stable/installation/) or with [Docker](./nextstrain-cli-docker/README.md))
+
+- AWS CLI (also included in Docker image)
+
+### AWS
+
+Running the commands below requires appropriate permission on S3, AWS Batch, and Cloudwatch, and setting env vars `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`; or `AWS_PROFILE`.
+
+
+## Running locally
+
+To run locally:
+```
+nextstrain build . --configfile config/config.yaml --config data_provenances=gisaid geo_resolutions=usa
+```
+
+## Running with AWS Batch
+
+To run on AWS, using Nextstrain's AWS Batch runtime:
+```
+nextstrain build --aws-batch --aws-batch-s3-bucket <bucket-name> --aws-batch-job <aws-batch-job-name> --aws-batch-queue <aws-batch-job-queue-name> . --configfile config/config.yaml --config data_provenances=gisaid geo_resolutions=usa
+```
+
+The results folder is automatically downloaded when completed. Alteratively, we can run this in the background with `--detach` and retrieve the results from S3 later.
+
+## Production setup
+
+### ECR and ECS
+
+In production, ECS is used to run the command above as a scheduled task, in detached mode.
+
+A minimal docker image including the Nextstrain CLI and contents of this repo is published to ECR and used to run the `nextstrain build` commands from ECS. See [README.md](nextstrain-cli-docker/README.md)
+
+An ECS task definition specifies the environment and nexstrain CLI command to run, and an ECS cluster runs this as a scheduled task.
+
+
+### Final S3 outputs 
+
+To update the files available from the public website, an addition workflow rule can be run by appending `config/sfa-optional.yaml` to the existing `--configfile` argument. The config file specifies the destination bucket, triggers the additional workflow that compresses and copies the files from the source bucket to the destination, and sets the appropriate encoding and content types for zipped files to be served via CloudFront. (i.e. `content-encoding:gzip and content-type:application/json`)

--- a/nextstrain-cli-docker/Dockerfile
+++ b/nextstrain-cli-docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM --platform=x86_64 ubuntu:latest
+
+WORKDIR /var/local
+COPY . .
+
+RUN apt-get update && apt-get install -y curl docker unzip
+
+RUN curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | /bin/bash
+
+RUN printf '\n%s\n' 'eval "$("/root/.nextstrain/cli-standalone/nextstrain" init-shell bash)"' >> ~/.bashrc
+RUN eval "$("/root/.nextstrain/cli-standalone/nextstrain" init-shell bash)"
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install

--- a/nextstrain-cli-docker/Dockerfile.dockerignore
+++ b/nextstrain-cli-docker/Dockerfile.dockerignore
@@ -1,0 +1,4 @@
+data/
+logs/
+results/
+benchmarks/

--- a/nextstrain-cli-docker/Dockerfile.dockerignore
+++ b/nextstrain-cli-docker/Dockerfile.dockerignore
@@ -2,3 +2,4 @@ data/
 logs/
 results/
 benchmarks/
+nextstrain-cli-docker/

--- a/nextstrain-cli-docker/README.md
+++ b/nextstrain-cli-docker/README.md
@@ -1,0 +1,41 @@
+# Minimal docker image for Nextstrain CLI
+
+#### Building the Docker image
+
+From the root directory of this repo:
+
+```
+docker build --tag nextstrain-cli -f ./nextstrain-cli-docker/Dockerfile .
+```
+
+#### Procedure
+We will push the Docker image to Amazon Elastic Container Registry (ECR), so that it's available from Elastic Container Service (ECS).
+
+This procedure assumes that the ECR repository has already been created.
+
+You will need to know several things:
+
+- **aws-account-id**: The AWS account ID, usually a 12-digit number
+- **aws-region**: The AWS region in which the application is stored in ECR and hosted in Elastic Beanstalk. (Hint: This is probably `us-west-2`!)
+- **ecr-repository-name**: The ECR repository name. (Hint: this is probably `nextstrain-cli`!)
+
+1. Authenticate with Amazon Elastic Container Registry (ECR)
+
+  Run this command, replacing `<region>` and `<aws-account-id>` as appropriate. The `--profile <aws-profile>` option is not necessary unless you are using named profiles with the AWS CLI.
+
+  ```
+  aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <aws-account-id>.dkr.ecr.<region>.amazonaws.com
+  ```
+
+  If you are using named profiles with the AWS CLI, you can add `—-profile <aws-profile-name>` to the `aws ecr get-login-password` command.
+  
+2. Tag the Docker image with the ECR repository.
+
+  ```
+  docker tag nextstrain-cli:latest <aws-account-id>.dkr.ecr.<region>.amazonaws.com/<ecr-repository-name>
+  ```
+3. Push the image to the repository.
+
+  ```
+  docker push <aws-account-id>.dkr.ecr.<region>.amazonaws.com/<ecr-repository-name>
+  ```

--- a/workflow/snakemake_rules/extract_washington.smk
+++ b/workflow/snakemake_rules/extract_washington.smk
@@ -1,0 +1,16 @@
+import json
+
+"""
+This part of the workflow extracts results for Washington.
+"""
+rule extract_washington:
+    """
+    Run script to extract results for Washington state
+    """
+    input: "results/{data_provenance}/{variant_classification}/{geo_resolution}/{model}/{date}_results.json"
+    output: "results/{data_provenance}/{variant_classification}/{geo_resolution}/{model}/{date}_washington.json"
+    
+    shell:
+        """
+        python ./scripts/extract-location.py < {input} > {output}
+        """

--- a/workflow/snakemake_rules/upload_sfa_forecast.smk
+++ b/workflow/snakemake_rules/upload_sfa_forecast.smk
@@ -1,0 +1,41 @@
+"""
+This part of the workflow uploads forecast results to S3 for the public website.
+"""
+
+def _get_s3_key(w, input_file):
+    s3_key_map = {
+        f"results/gisaid/nextstrain_clades/usa/mlr/{w.date}_results.json.gz": f"data/us_states/us_nextstrain_clades.json",
+        f"results/gisaid/nextstrain_clades/usa/mlr/{w.date}_washington.json.gz": f"data/wa/wa_nextstrain_clades.json",
+        f"results/gisaid/pango_lineages/usa/mlr/{w.date}_results.json.gz": f"data/us_states/us_pango_lineages.json",
+        f"results/gisaid/pango_lineages/usa/mlr/{w.date}_washington.json.gz": f"data/wa/wa_pango_lineages.json",
+    }
+    assert input_file in s3_key_map, f"Unexpected file for upload to S3: {input_file}"
+    return s3_key_map[input_file]
+
+rule zip_files:
+    input:
+        us_results = "results/{data_provenance}/{variant_classification}/usa/{model}/{date}_results.json",
+        wa_results = "results/{data_provenance}/{variant_classification}/usa/{model}/{date}_washington.json"
+    output:
+        "results/{data_provenance}/{variant_classification}/usa/{model}/{date}_results.json.gz",
+        "results/{data_provenance}/{variant_classification}/usa/{model}/{date}_washington.json.gz"
+    shell:
+        """
+        gzip -k {input.us_results} && gzip -k {input.wa_results}
+        """
+
+rule upload_zip_files_to_s3:
+    input:
+        us_results = "results/{data_provenance}/{variant_classification}/usa/{model}/{date}_results.json.gz",
+        wa_results = "results/{data_provenance}/{variant_classification}/usa/{model}/{date}_washington.json.gz"
+    output:
+        s3_upload_complete = touch("results/{data_provenance}/{variant_classification}/usa/{model}/{date}_s3_upload.done")
+    params:
+        s3_bucket = config.get("sfa_s3_bucket"),
+        us_s3_key = lambda w, input: _get_s3_key(w, input.us_results),
+        wa_s3_key = lambda w, input: _get_s3_key(w, input.wa_results)
+    shell:
+        """
+        aws s3api put-object --bucket {params.s3_bucket} --key {params.us_s3_key} --content-encoding gzip --content-type application/json --body {input.us_results} && \
+        aws s3api put-object --bucket {params.s3_bucket} --key {params.wa_s3_key} --content-encoding gzip --content-type application/json --body {input.wa_results}
+        """

--- a/workflow/snakemake_rules/upload_sfa_forecast.smk
+++ b/workflow/snakemake_rules/upload_sfa_forecast.smk
@@ -31,7 +31,7 @@ rule upload_zip_files_to_s3:
     output:
         s3_upload_complete = touch("results/{data_provenance}/{variant_classification}/usa/{model}/{date}_s3_upload.done")
     params:
-        s3_bucket = config.get("sfa_s3_bucket"),
+        s3_bucket = os.environ["sfa_s3_bucket"],
         us_s3_key = lambda w, input: _get_s3_key(w, input.us_results),
         wa_s3_key = lambda w, input: _get_s3_key(w, input.wa_results)
     shell:


### PR DESCRIPTION
Changes needed to fully automate US states covid forecasting model pipeline.

- Disabled some of the internal Nextstrain rules that we won't use.

 - Added rules to extract Washington results to separate files, zip Washington and US results for clades and pango lineages, and upload to S3 with correct encoding and content-type to serve the compressed files from CloudFront.

 - Dockerized Nextstrain CLI for use with Elastic Container Service.
