### PR TITLE
Updates for SFA forecasting UI datasets

### DIFF
--- a/viz/.env.us-states
+++ b/viz/.env.us-states
@@ -1,0 +1,5 @@
+# US states
+VITE_URL_PATH_BASE=/forecasts-ncov-us-states/
+VITE_DATA_PREFIX=us_states/us_
+
+VITE_DATA_BASE_URL=https://covidforecasting.brotmanbaty.org/data

--- a/viz/.env.wa-state
+++ b/viz/.env.wa-state
@@ -1,0 +1,5 @@
+# WA state
+VITE_URL_PATH_BASE=/forecasts-ncov-wa/
+VITE_DATA_PREFIX=wa/wa_
+
+VITE_DATA_BASE_URL=https://covidforecasting.brotmanbaty.org/data

--- a/viz/package.json
+++ b/viz/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview",
+    "build": "vite build --mode=${MODE=us-states}",
+    "preview": "vite preview --mode=${MODE=us-states}",
     "start:local": "bash ./scripts/run-local.sh production",
     "start:local:dev": "bash ./scripts/run-local.sh"
   },

--- a/viz/src/App.jsx
+++ b/viz/src/App.jsx
@@ -1,18 +1,19 @@
 import { PanelDisplay, useModelData } from '@nextstrain/evofr-viz';
 import '@nextstrain/evofr-viz/dist/index.css';
 
-const customAddress = !!import.meta.env.VITE_DATA_HOST;
+const customAddress = !!import.meta.env.VITE_DATA_BASE_URL;
+
 const mlrCladesConfig = {
     modelName: "mlr_clades",
     modelUrl: customAddress ?
-      `${import.meta.env.VITE_DATA_HOST}/${import.meta.env.VITE_CLADES_PATH}` :
-      `https://nextstrain-data.s3.amazonaws.com/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/global/mlr/latest_results.json`,
+      `${import.meta.env.VITE_DATA_BASE_URL}/${import.meta.env.VITE_DATA_PREFIX}nextstrain_clades.json`
+      : `https://nextstrain-data.s3.amazonaws.com/files/workflows/forecasts-ncov/gisaid/nextstrain_clades/global/mlr/latest_results.json`,
 }
 const mlrLineagesConfig = {
     modelName: "mlr_lineages",
     modelUrl: customAddress ?
-      `${import.meta.env.VITE_DATA_HOST}/${import.meta.env.VITE_LINEAGES_PATH}` :
-      `https://nextstrain-data.s3.amazonaws.com/files/workflows/forecasts-ncov/gisaid/pango_lineages/global/mlr/latest_results.json`,
+      `${import.meta.env.VITE_DATA_BASE_URL}/${import.meta.env.VITE_DATA_PREFIX}pango_lineages.json`
+      : `https://nextstrain-data.s3.amazonaws.com/files/workflows/forecasts-ncov/gisaid/pango_lineages/global/mlr/latest_results.json`,
 }
 
 function App() {

--- a/viz/vite.config.js
+++ b/viz/vite.config.js
@@ -1,10 +1,14 @@
-import { defineConfig } from 'vite'
+import {defineConfig, loadEnv} from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  // The base must match repo name since we are deploying the site to https://nextstrain.github.io/forecasts-ncov/
-  // See vite docs on deploying to GH pages: https://vitejs.dev/guide/static-deploy.html#github-pages
-  base: "/forecasts-ncov/",
-  plugins: [react()],
+export default defineConfig(({mode}) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    // The base is specific to each vite MODE environment, since we are deploying to:
+    // https://covidforecasting.brotmanbaty.org/forecasts-ncov-wa/index.html and
+    // https://covidforecasting.brotmanbaty.org/forecasts-ncov-us-states/index.html
+    base: env.VITE_URL_PATH_BASE,
+    plugins: [react()],
+  }
 })


### PR DESCRIPTION
Adding two vizualization UI env files for use with VITE MODE (`us-states` or `wa-state`) when building. The public website currently uses both versions.

Updates the URLs of the model files to reflect their current location and naming conventions, utilizing environment variables where possible.